### PR TITLE
feat: docs point to latest released version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /public
 /temp
 *.iml
+version.txt

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,9 +1,12 @@
 const {defaultLangKey} = require('./src/i18n');
+const {readLatestVersion} = require('./src/jkube-utils');
+
+const latestJKubeVersion = readLatestVersion();
 
 const config = {
   siteMetadata: {
     title: 'Eclipse JKube',
-    author: 'JKube Development Team',
+    author: 'Eclipse JKube Development Team',
     siteUrl: 'https://eclipse.org/jkube',
   },
   pathPrefix: '/jkube',
@@ -23,6 +26,7 @@ const config = {
       options: {
         name: 'jkube',
         remote: 'https://github.com/eclipse/jkube.git',
+        branch: `v${latestJKubeVersion}`,
         patterns: [
           'kubernetes-maven-plugin/doc/**/index.adoc',
           'openshift-maven-plugin/doc/**/index.adoc'
@@ -32,7 +36,10 @@ const config = {
     {
       resolve: 'gatsby-transformer-asciidoc',
       options: {
-        safe: 'unsafe'
+        safe: 'unsafe',
+        attributes: {
+          version: latestJKubeVersion
+        }
       }
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2341,12 +2341,11 @@
       "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
     },
     "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
+        "follow-redirects": "1.5.10"
       }
     },
     "axobject-query": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Website for Eclipse JKube project",
   "main": "index.js",
   "scripts": {
-    "build": "rm -rf ./.cache ./public && gatsby build --prefix-paths",
-    "develop": "rm -rf ./.cache ./public && gatsby develop --host=0.0.0.0",
+    "build": "node ./scripts/jkube-version-finder.js && rm -rf ./.cache ./public && gatsby build --prefix-paths",
+    "develop": "node ./scripts/jkube-version-finder.js && rm -rf ./.cache ./public && gatsby develop --host=0.0.0.0",
     "pretest": "eslint --ignore-path .gitignore .",
     "start": "npm run develop",
     "test": "jest"
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/jkubeio/jkube-website#readme",
   "devDependencies": {
+    "axios": "^0.19.2",
     "eslint": "^6.8.0",
     "eslint-plugin-react": "^7.17.0"
   },

--- a/scripts/jkube-version-finder.js
+++ b/scripts/jkube-version-finder.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const jkubeUtils = require('../src/jkube-utils');
+
+const handleError = error => {
+  console.error(error);
+  process.exit(1);
+};
+
+jkubeUtils.saveLatestVersion().then(() => process.exit(0)).catch(handleError);

--- a/src/jkube-utils.js
+++ b/src/jkube-utils.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const axios = require('axios');
+const xml2js = require('xml2js');
+
+const VERSION_FILENAME = 'version.txt';
+const METADATA_URL = 'https://repo1.maven.org/maven2/org/eclipse/jkube/jkube/maven-metadata.xml';
+
+const getLatestVersion = async () => {
+  const {data: xmlMetadata} = await axios.get(METADATA_URL);
+  const jsonMetadata = await xml2js.Parser().parseStringPromise(xmlMetadata);
+  return jsonMetadata.metadata.versioning[0].latest[0];
+};
+
+const saveLatestVersion = async () => {
+  const latestVersion = await getLatestVersion();
+  console.log(`JKube latest version is: ${latestVersion}`);
+  fs.writeFileSync(VERSION_FILENAME, latestVersion);
+};
+
+const readLatestVersion = () => {
+  return fs.readFileSync(VERSION_FILENAME);
+};
+
+module.exports = {
+  saveLatestVersion,
+  readLatestVersion
+};

--- a/src/pages/community/index.md
+++ b/src/pages/community/index.md
@@ -53,8 +53,9 @@ Check our team's plans in Eclipse JKube's [projects](https://github.com/eclipse/
 ### Team Calendar
 
 Stay tuned to our
-[public calendar](https://calendar.google.com/calendar/embed?src=n38b3vf86tupe7ennn65ntmchk%40group.calendar.google.com&ctz=Europe%2FMadrid)
-to see when our next Sprint planning or meeting happens and feel free to join.
+[public calendar](https://calendar.google.com/calendar/embed?src=n38b3vf86tupe7ennn65ntmchk%40group.calendar.google.com&ctz=GMT)
+to see when our next Sprint planning or meeting happens and feel free to join our
+[public meeting room](https://bluejeans.com/656779179).
 
 <div class="calendar">
 


### PR DESCRIPTION
- Asciidoc sources come from latest release version (eclipse/jkube:v$latestVersion)
- Docs have `{version} ` placeholder replaced by latest released version
- Community page contains visible link to Bluejeans meeting room