### PR TITLE
doc : Remove Katakoda section from website and footer

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -25,7 +25,6 @@ export const Footer = ({lang}) => {
           <li><Link to={resolvePath('/docs#getting-started')}>Get Started</Link></li>
           <li><Link to={resolvePath('/docs')}>Docs</Link></li>
           <li><Link to={resolvePath('/quickstarts')}>Quickstarts</Link></li>
-          <li><Link to={resolvePath('/docs#katacoda-courses')}>Katacoda Courses</Link></li>
           <li><Link to={resolvePath('/demos')}>Demos</Link></li>
         </ul>
         <ul className='eclipse-jkube-footer__links-list'>

--- a/src/pages/docs/index.md
+++ b/src/pages/docs/index.md
@@ -26,20 +26,6 @@ description: "Eclipse JKube Documentation Index"
 Visit our [quickstart samples](/quickstarts) on GitHub to check
 available examples for your favourite framework or vanilla Java.
 
-### Katacoda Courses
-
-If you want to get a taste of Eclipse JKube but don't want to install anything on your machine or don't have an
-available development environment you can try out our [Katacoda courses](https://katacoda.com/jkubeio):
-
-<div class="highlight">
-
-![Katacoda Courses](katacoda-logo.png "Katacoda logo")
-
-* [**Getting started**](https://katacoda.com/jkubeio/courses/getting-started): Several scenarios to get started with
-  Eclipse JKube using your favourite Java framework.
-
-</div>
-
 ## Javadoc
 
 ### JKube Kit


### PR DESCRIPTION
Related to https://github.com/eclipse/jkube/issues/1879

Katakoda.com is no longer active.

+ Remove Katakoda section from `/docs` page
+ Remove `Katakoda Courses` footer

Signed-off-by: Rohan Kumar <rohaan@redhat.com>