### PR TITLE
fix : Update website title to align with GitHub description

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -1,8 +1,8 @@
 ---
 path: "/"
 date: "2020-01-02"
-title: "Eclipse JKube - Successor of the deprecated Fabric8 Maven Plugin"
-description: "Eclipse - Successor of the deprecated Fabric8 Maven Plugin"
+title: "Eclipse JKube - Build and Deploy java applications on Kubernetes"
+description: "Eclipse JKube - Build and Deploy java applications on Kubernetes"
 ---
 <div class="hero">
 <div class="hero-content">


### PR DESCRIPTION
Our website title is outdated and is not aligned with what's described on GitHub.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>