### PR TITLE
fix: base url is now eclipse.dev/jkube

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to www.eclipse.org/jkube
+name: Deploy to www.eclipse.dev/jkube
 
 on:
   push:

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,7 +7,7 @@ const config = {
   siteMetadata: {
     title: 'Eclipse JKube',
     author: 'Eclipse JKube Development Team',
-    siteUrl: 'https://eclipse.org/jkube',
+    siteUrl: 'https://eclipse.dev/jkube',
   },
   pathPrefix: '/jkube',
   plugins: [


### PR DESCRIPTION
Moved from eclipse.org/jkube
https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/30693

Part of https://github.com/eclipse/jkube/issues/2148